### PR TITLE
chore: fix CI

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,12 @@
-.gitignore
+# Next.js build output
+.next
+out
+
+# Ignore all Markdown files
+*.md
+
+# Generated files of Contracts
+artifacts
+cache
+typechain
+packages/**/dist


### PR DESCRIPTION
CI が壊れていたのと、.gitignore を参照することで無視しなくていいファイルまで無視されていたのを修正しました。お手すきの際にご確認ください。