### PR TITLE
chore: add procfile

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: yarn deploy:bot

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,0 @@
-web: npm run deploy:bot

--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: yarn deploy:bot
+web: npm run deploy:bot

--- a/package.json
+++ b/package.json
@@ -41,8 +41,7 @@
     "postpublish": "pinst --enable",
     "release": "semantic-release",
     "release:check": "semantic-release --dry-run",
-    "test": "turbo run test",
-    "deploy:bot": "yarn workspace @wagumi/bot deploy"
+    "test": "turbo run test"
   },
   "npmpackagejsonlint": {
     "extends": "npm-package-json-lint-config-default"

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "postpublish": "pinst --enable",
     "release": "semantic-release",
     "release:check": "semantic-release --dry-run",
-    "test": "turbo run test"
+    "test": "turbo run test",
+    "deploy:bot": "yarn workspace @wagumi/bot deploy"
   },
   "npmpackagejsonlint": {
     "extends": "npm-package-json-lint-config-default"

--- a/packages/bot/Procfile
+++ b/packages/bot/Procfile
@@ -1,0 +1,1 @@
+web: npm run deploy

--- a/packages/bot/package.json
+++ b/packages/bot/package.json
@@ -17,7 +17,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "nodemon src/index.ts",
-    "start": "node ."
+    "start": "node .",
+    "deploy": "tsc && node ."
   },
   "dependencies": {
     "discord.js": "^12.5.3",


### PR DESCRIPTION
# 概要

下記の設定とコマンド構成で PR 作成時に自動デプロイ処理がトリガーされるかを確認します。

1. Deployments > Triggers > Root Directory 設定確認
➡️ 現状の `/packages/bot` のまま
2. /packages/bot/Procfile を追加
➡️ Procfile で Bot デプロイ用スクリプト ( `npm run deploy` )を指定
※デプロイをトリガーするコマンドがデフォルトでは npm start のため。
3. Deployments > Settings > Start Command 設定追加
➡️ Procfile にセットされたコマンドでデプロイをトリガーするため `npm run deploy` を設定

| Root Directory 設定 | Start Command 設定 |
| --- | --- |
| <img width="320" alt="スクリーンショット 2022-02-06 11 58 55" src="https://user-images.githubusercontent.com/6182830/152666167-64c13849-d917-404e-84ae-1a4a6d7fee06.png"> | <img width="320" alt="スクリーンショット 2022-02-06 11 58 37" src="https://user-images.githubusercontent.com/6182830/152666177-2cc8f8f6-4d75-4ff1-9a94-b20d21b4b3f0.png"> |


## 設定とコマンド構成の選択理由について

1. 対象の Railway プロジェクトでは wagumi bot だけ Clone したいため以下の設定は正しいと考えられました (参考1)。
※Docs は Isolated Monorepo 用との記載でしたが今回のユースケース的に合っている認識です。
2. Railway の自動デプロイ処理はコマンド実行（デフォルトは npm start）によりトリガーされるので、Bot デプロイ用のコマンド指定 (Procfile) を /packages/bot に作成しました (参考2)。
3. デプロイ用のコマンドをカスタマイズしたため、Railway の Start Command にコマンドをセットしました (参考3)。

参考: Railway Doc
1. [Isolated Monorepo](https://docs.railway.app/deploy/monorepo#isolated-monorepo)
2. [Sample Node Procfile](https://docs.railway.app/deploy/nodejs)
3. [Shared Monorepo](https://docs.railway.app/deploy/monorepo#shared-monorepo)
